### PR TITLE
TransPowerBase: correct path to java files

### DIFF
--- a/TransPowerBase/Android.mk
+++ b/TransPowerBase/Android.mk
@@ -8,7 +8,7 @@ LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := true
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_SRC_FILES := $(call all-java-files-under, src)
+LOCAL_SRC_FILES := $(call all-java-files-under, ../common/src)
 LOCAL_RESOURCE_DIR := \
     $(LOCAL_PATH)/../common/res
 


### PR DESCRIPTION
The path TransPowerBase/src does not exist.
Changing it to point at ../common/src like how it is done for LOCAL_RESOURCE_DIR makes the app build.