### PR TITLE
[master] Android.mk: Use PRODUCT_PLATFORM_SOD as build barrier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,4 +1,8 @@
 # Licensed under the LICENSE.
 # Copyright 2017, Sony Mobile Communications Inc.
+ifeq ($(PRODUCT_PLATFORM_SOD),true)
+
 LOCAL_PATH:= $(call my-dir)
 include $(call all-makefiles-under,$(LOCAL_PATH))
+
+endif


### PR DESCRIPTION
We use PRODUCT_PLATFORM_SOD as a build barrier on all OSS repos
to avoid unpredictable inclusion during the build for non-Sony products.