### PR TITLE
Add guards to check for SHIPPING_API_LEVEL

### DIFF
--- a/TransPowerAcc/Android.mk
+++ b/TransPowerAcc/Android.mk
@@ -9,7 +9,9 @@ LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_PRIVATE_PLATFORM_APIS := true
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 res_dirs := \

--- a/TransPowerBase/Android.mk
+++ b/TransPowerBase/Android.mk
@@ -9,7 +9,9 @@ LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_PRIVATE_PLATFORM_APIS := true
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
 
 LOCAL_SRC_FILES := $(call all-java-files-under, ../common/src)
 LOCAL_RESOURCE_DIR := \

--- a/TransPowerProx/Android.mk
+++ b/TransPowerProx/Android.mk
@@ -9,7 +9,9 @@ LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_PRIVATE_PLATFORM_APIS := true
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 res_dirs := \

--- a/TransPowerSensors/Android.mk
+++ b/TransPowerSensors/Android.mk
@@ -9,7 +9,9 @@ LOCAL_PRIVILEGED_MODULE := true
 LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_PRIVATE_PLATFORM_APIS := true
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 

--- a/common-sensor/Android.mk
+++ b/common-sensor/Android.mk
@@ -6,7 +6,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := TransPowerCommonSensor
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_PRIVATE_PLATFORM_APIS := true
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
+
 LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -6,7 +6,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := TransPowerCommon
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_PRIVATE_PLATFORM_APIS := true
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
+
 LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)

--- a/libpower/Android.mk
+++ b/libpower/Android.mk
@@ -6,7 +6,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := libpower
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_PRIVATE_PLATFORM_APIS := true
+ifneq ($(shell echo "$(PLATFORM_SDK_VERSION)" ),$(shell echo "$(PRODUCT_SHIPPING_API_LEVEL)" ))
+    LOCAL_PRIVATE_PLATFORM_APIS := true
+endif
+
 LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)


### PR DESCRIPTION
Lets add a guard to check for shipping api level and if its equal to SDK version.

This fixes error in building if shipping api level is equal to SDK version.

Specifies both LOCAL_SDK_VERSION (system_current) and LOCAL_PRIVATE_PLATFORM_APIS (true) but should specify only one.