### PR TITLE
[Android-10] Telephony: Do not instantiate PhoneStateListener with subId

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,10 +10,10 @@ Felix Elsner <google@ix5.org>
 Honggang Luo <honggang.x.luo@sony.com>
 Kitta Koutarou <koutarou.x.kitta@sonymobile.com>
 Kosuge Yuji <yuji.x.kosuge@sonymobile.com>
+Marijn Suijten <marijns95@gmail.com>
 Mats Åkesson <mats2.akesson@sonymobile.com>
 Oyamada Daisuke <daisuke.oyamada@sony.com>
 Ping Sun <ping.x.sun@sony.com>
 Wei Huang <wei.x.huang@sony.com>
 yuejun sun <yuejun.sun@sonymobile.com>
 Zoran Jovanovic <zoran.jovanovic@sony.com>
-


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/463

subId has been dropped from the constructor, and will later be removed
from the PhoneStateListener class entirerly. Instead, the listener
should be registered through a TelephonyManager for that specific subId.
See:
https://android.googlesource.com/platform/frameworks/base/+/84a90870aa021fa168fab4db613fb87f8d58a4c1
for the relevant change that throws an InvalidArgumentException when
trying to instantiate the class with a subId.

Note that this requires the TelephonyManager to stay around for
deregistration, since it is responsible for carrying the number since Q.
For that reason, it has been stuffed with the PhoneStateListenerImpl
even though that's not the nicest design choice. See the relevant
listen() method here:
https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-10.0.0_r2/telephony/java/android/telephony/TelephonyManager.java#5025

This should be compatible with Pie, where the subId is also stored in
TelephonyManager, and used as default when PhoneStateListener is created
with the default constructor:
https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-9.0.0_r48/telephony/java/android/telephony/TelephonyManager.java#4212

Tagging @jzoran for review.

Tested on Discovery (SS) @ Android 9;
Mermaid (DSDS) + Akatsuki (DSDS) @ Android 10.
All with a single sim.

### TODO:
- [ ] Test this on a DSDS device _with two sims inserted_.