### PR TITLE
[TRANSPOWER] [1/4] Convert to AndroidX

### DIFF
--- a/TransPowerAcc/src/com/sony/transmitpower/sensor/SensorFeature.java
+++ b/TransPowerAcc/src/com/sony/transmitpower/sensor/SensorFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 import com.sony.transmitpower.feature.IFeature;
@@ -69,4 +69,3 @@ public final class SensorFeature implements IFeature {
         mAccelerometer.clean();
     }
 }
-

--- a/TransPowerBase/Android.mk
+++ b/TransPowerBase/Android.mk
@@ -16,8 +16,10 @@ LOCAL_RESOURCE_DIR := \
     $(LOCAL_PATH)/../common/res
 
 LOCAL_JAVA_LIBRARIES += telephony-common
-LOCAL_STATIC_JAVA_LIBRARIES += \
+LOCAL_STATIC_ANDROID_LIBRARIES += \
     android-support-v4 \
+    androidx.annotation_annotation
+LOCAL_STATIC_JAVA_LIBRARIES += \
     libpower
 
 # proguard:

--- a/TransPowerBase/Android.mk
+++ b/TransPowerBase/Android.mk
@@ -17,8 +17,8 @@ LOCAL_RESOURCE_DIR := \
 
 LOCAL_JAVA_LIBRARIES += telephony-common
 LOCAL_STATIC_ANDROID_LIBRARIES += \
-    android-support-v4 \
-    androidx.annotation_annotation
+    androidx.annotation_annotation \
+    androidx.localbroadcastmanager_localbroadcastmanager
 LOCAL_STATIC_JAVA_LIBRARIES += \
     libpower
 

--- a/TransPowerProx/src/com/sony/transmitpower/sensor/SensorFeature.java
+++ b/TransPowerProx/src/com/sony/transmitpower/sensor/SensorFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 import com.sony.transmitpower.feature.IFeature;
@@ -70,4 +70,3 @@ public final class SensorFeature implements IFeature {
         mProximity.clean();
     }
 }
-

--- a/TransPowerSensors/src/com/sony/transmitpower/sensor/SensorFeature.java
+++ b/TransPowerSensors/src/com/sony/transmitpower/sensor/SensorFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 import com.sony.transmitpower.feature.IFeature;
@@ -93,4 +93,3 @@ public final class SensorFeature implements IFeature {
         mProximity.clean();
     }
 }
-

--- a/common-sensor/src/com/sony/transmitpower/sensor/SensorBase.java
+++ b/common-sensor/src/com/sony/transmitpower/sensor/SensorBase.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;

--- a/common-sensor/src/com/sony/transmitpower/sensor/observer/SensorObserver.java
+++ b/common-sensor/src/com/sony/transmitpower/sensor/observer/SensorObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.telephony.ServiceState;
 

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -11,7 +11,9 @@ LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
-LOCAL_STATIC_ANDROID_LIBRARIES += android-support-v4
+LOCAL_STATIC_ANDROID_LIBRARIES += \
+    android-support-v4 \
+    androidx.annotation_annotation
 LOCAL_STATIC_JAVA_LIBRARIES := libpower
 LOCAL_JAVA_LIBRARIES += telephony-common
 

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -12,8 +12,8 @@ LOCAL_PROPRIETARY_MODULE := true
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
 LOCAL_STATIC_ANDROID_LIBRARIES += \
-    android-support-v4 \
-    androidx.annotation_annotation
+    androidx.annotation_annotation \
+    androidx.localbroadcastmanager_localbroadcastmanager
 LOCAL_STATIC_JAVA_LIBRARIES := libpower
 LOCAL_JAVA_LIBRARIES += telephony-common
 

--- a/common/proguard.flags
+++ b/common/proguard.flags
@@ -1,5 +1,5 @@
 -verbose
--keep class android.support.v4.content.LocalBroadcastManager {
+-keep class androidx.localbroadcastmanager.content.LocalBroadcastManager {
       *;
 }
 -keep class com.sony.transmitpower.BootCompletedReceiver {
@@ -11,4 +11,3 @@
 -keep class com.sony.transmitpower.service.InCallObserverService {
       *;
 }
-

--- a/common/src/com/sony/transmitpower/feature/IFeature.java
+++ b/common/src/com/sony/transmitpower/feature/IFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.feature;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 /**

--- a/common/src/com/sony/transmitpower/observer/ObserverMediator.java
+++ b/common/src/com/sony/transmitpower/observer/ObserverMediator.java
@@ -9,7 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.sony.transmitpower.Transmitter;
 import com.sony.transmitpower.feature.IFeature;

--- a/common/src/com/sony/transmitpower/observer/ObserverMediator.java
+++ b/common/src/com/sony/transmitpower/observer/ObserverMediator.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/common/src/com/sony/transmitpower/observer/PowerObserverBase.java
+++ b/common/src/com/sony/transmitpower/observer/PowerObserverBase.java
@@ -6,7 +6,7 @@ package com.sony.transmitpower.observer;
 
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.sony.transmitpower.util.Util;
 

--- a/common/src/com/sony/transmitpower/observer/ScreenObserver.java
+++ b/common/src/com/sony/transmitpower/observer/ScreenObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/common/src/com/sony/transmitpower/observer/TelecommObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelecommObserver.java
@@ -9,7 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.android.collect.Sets;
 

--- a/common/src/com/sony/transmitpower/observer/TelecommObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelecommObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/common/src/com/sony/transmitpower/observer/TelephonyStateObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelephonyStateObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.media.AudioManager;
 import android.telephony.PhoneStateListener;

--- a/common/src/com/sony/transmitpower/service/InCallObserverService.java
+++ b/common/src/com/sony/transmitpower/service/InCallObserverService.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.service;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;

--- a/common/src/com/sony/transmitpower/service/InCallObserverService.java
+++ b/common/src/com/sony/transmitpower/service/InCallObserverService.java
@@ -8,7 +8,7 @@ import androidx.annotation.NonNull;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.telecom.Call;
 import android.telecom.CallAudioState;
 import android.telecom.InCallService;

--- a/common/src/com/sony/transmitpower/util/Util.java
+++ b/common/src/com/sony/transmitpower/util/Util.java
@@ -4,8 +4,8 @@
  */
 package com.sony.transmitpower.util;
 
-import android.annotation.NonNull;
-import android.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;

--- a/libacc/src/com/sony/transmitpower/sensor/Accelerometer.java
+++ b/libacc/src/com/sony/transmitpower/sensor/Accelerometer.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;

--- a/libacc/src/com/sony/transmitpower/sensor/util/Vector.java
+++ b/libacc/src/com/sony/transmitpower/sensor/util/Vector.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor.util;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class Vector {
     public float x;

--- a/libproximity/src/com/sony/transmitpower/sensor/Proximity.java
+++ b/libproximity/src/com/sony/transmitpower/sensor/Proximity.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;


### PR DESCRIPTION
`android.annotation.NonNull` is internal and cannot be used when SDK/API boundaries come online. Furthermore, support libraries are deprecated and should be migrated to AndroidX. This pulls `LocalBroadcastManager` from the new support libraries.

### TODO:
It doesn't really seem to matter whether `LOCAL_STATIC_ANDROID_LIBRARIES` or `LOCAL_STATIC_JAVA_LIBRARIES` is used, as these libs don't include any resources anyway (they are at least unused in TransPower).