### PR TITLE
[TRANSPOWER] [2/4] [DONOTMERGE] Switch to public SDK components

### DIFF
--- a/TransPowerAcc/Android.mk
+++ b/TransPowerAcc/Android.mk
@@ -23,7 +23,6 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
 
 hidden_api_major_vers := 28
 ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), $(hidden_api_major_vers)),)
-    LOCAL_JAVA_LIBRARIES += telephony-common
     LOCAL_USE_AAPT2 := true
 endif
 

--- a/TransPowerAcc/src/com/sony/transmitpower/sensor/SensorFeature.java
+++ b/TransPowerAcc/src/com/sony/transmitpower/sensor/SensorFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 import com.sony.transmitpower.feature.IFeature;
@@ -69,4 +69,3 @@ public final class SensorFeature implements IFeature {
         mAccelerometer.clean();
     }
 }
-

--- a/TransPowerBase/Android.mk
+++ b/TransPowerBase/Android.mk
@@ -16,8 +16,10 @@ LOCAL_RESOURCE_DIR := \
     $(LOCAL_PATH)/../common/res
 
 LOCAL_JAVA_LIBRARIES += telephony-common
-LOCAL_STATIC_JAVA_LIBRARIES += \
+LOCAL_STATIC_ANDROID_LIBRARIES += \
     android-support-v4 \
+    androidx.annotation_annotation
+LOCAL_STATIC_JAVA_LIBRARIES += \
     libpower
 
 # proguard:

--- a/TransPowerBase/Android.mk
+++ b/TransPowerBase/Android.mk
@@ -15,7 +15,6 @@ LOCAL_SRC_FILES := $(call all-java-files-under, ../common/src)
 LOCAL_RESOURCE_DIR := \
     $(LOCAL_PATH)/../common/res
 
-LOCAL_JAVA_LIBRARIES += telephony-common
 LOCAL_STATIC_ANDROID_LIBRARIES += \
     androidx.annotation_annotation \
     androidx.localbroadcastmanager_localbroadcastmanager

--- a/TransPowerBase/Android.mk
+++ b/TransPowerBase/Android.mk
@@ -17,8 +17,8 @@ LOCAL_RESOURCE_DIR := \
 
 LOCAL_JAVA_LIBRARIES += telephony-common
 LOCAL_STATIC_ANDROID_LIBRARIES += \
-    android-support-v4 \
-    androidx.annotation_annotation
+    androidx.annotation_annotation \
+    androidx.localbroadcastmanager_localbroadcastmanager
 LOCAL_STATIC_JAVA_LIBRARIES += \
     libpower
 

--- a/TransPowerProx/Android.mk
+++ b/TransPowerProx/Android.mk
@@ -20,10 +20,6 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
     libpower \
     libprox
 
-ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28),)
-    LOCAL_JAVA_LIBRARIES += telephony-common
-endif
-
 LOCAL_AAPT_FLAGS := --auto-add-overlay
 
 # proguard:

--- a/TransPowerProx/src/com/sony/transmitpower/sensor/SensorFeature.java
+++ b/TransPowerProx/src/com/sony/transmitpower/sensor/SensorFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 import com.sony.transmitpower.feature.IFeature;
@@ -70,4 +70,3 @@ public final class SensorFeature implements IFeature {
         mProximity.clean();
     }
 }
-

--- a/TransPowerSensors/Android.mk
+++ b/TransPowerSensors/Android.mk
@@ -22,7 +22,6 @@ LOCAL_STATIC_JAVA_LIBRARIES += libacc libpower libprox
 
 hidden_api_major_vers := 28
 ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), $(hidden_api_major_vers)),)
-    LOCAL_JAVA_LIBRARIES += telephony-common
     LOCAL_USE_AAPT2 := true
 endif
 

--- a/TransPowerSensors/src/com/sony/transmitpower/sensor/SensorFeature.java
+++ b/TransPowerSensors/src/com/sony/transmitpower/sensor/SensorFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 import com.sony.transmitpower.feature.IFeature;
@@ -93,4 +93,3 @@ public final class SensorFeature implements IFeature {
         mProximity.clean();
     }
 }
-

--- a/common-sensor/src/com/sony/transmitpower/sensor/SensorBase.java
+++ b/common-sensor/src/com/sony/transmitpower/sensor/SensorBase.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;

--- a/common-sensor/src/com/sony/transmitpower/sensor/observer/SensorObserver.java
+++ b/common-sensor/src/com/sony/transmitpower/sensor/observer/SensorObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.telephony.ServiceState;
 

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -11,7 +11,9 @@ LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
-LOCAL_STATIC_ANDROID_LIBRARIES += android-support-v4
+LOCAL_STATIC_ANDROID_LIBRARIES += \
+    android-support-v4 \
+    androidx.annotation_annotation
 LOCAL_STATIC_JAVA_LIBRARIES := libpower
 LOCAL_JAVA_LIBRARIES += telephony-common
 

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -15,6 +15,5 @@ LOCAL_STATIC_ANDROID_LIBRARIES += \
     androidx.annotation_annotation \
     androidx.localbroadcastmanager_localbroadcastmanager
 LOCAL_STATIC_JAVA_LIBRARIES := libpower
-LOCAL_JAVA_LIBRARIES += telephony-common
 
 include $(BUILD_STATIC_JAVA_LIBRARY)

--- a/common/Android.mk
+++ b/common/Android.mk
@@ -12,8 +12,8 @@ LOCAL_PROPRIETARY_MODULE := true
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
 LOCAL_STATIC_ANDROID_LIBRARIES += \
-    android-support-v4 \
-    androidx.annotation_annotation
+    androidx.annotation_annotation \
+    androidx.localbroadcastmanager_localbroadcastmanager
 LOCAL_STATIC_JAVA_LIBRARIES := libpower
 LOCAL_JAVA_LIBRARIES += telephony-common
 

--- a/common/proguard.flags
+++ b/common/proguard.flags
@@ -1,5 +1,5 @@
 -verbose
--keep class android.support.v4.content.LocalBroadcastManager {
+-keep class androidx.localbroadcastmanager.content.LocalBroadcastManager {
       *;
 }
 -keep class com.sony.transmitpower.BootCompletedReceiver {
@@ -11,4 +11,3 @@
 -keep class com.sony.transmitpower.service.InCallObserverService {
       *;
 }
-

--- a/common/src/com/sony/transmitpower/feature/IFeature.java
+++ b/common/src/com/sony/transmitpower/feature/IFeature.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.feature;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 
 /**

--- a/common/src/com/sony/transmitpower/observer/ObserverMediator.java
+++ b/common/src/com/sony/transmitpower/observer/ObserverMediator.java
@@ -9,7 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.sony.transmitpower.Transmitter;
 import com.sony.transmitpower.feature.IFeature;

--- a/common/src/com/sony/transmitpower/observer/ObserverMediator.java
+++ b/common/src/com/sony/transmitpower/observer/ObserverMediator.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/common/src/com/sony/transmitpower/observer/PowerObserverBase.java
+++ b/common/src/com/sony/transmitpower/observer/PowerObserverBase.java
@@ -6,7 +6,7 @@ package com.sony.transmitpower.observer;
 
 import android.content.Context;
 import android.content.Intent;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.sony.transmitpower.util.Util;
 

--- a/common/src/com/sony/transmitpower/observer/ScreenObserver.java
+++ b/common/src/com/sony/transmitpower/observer/ScreenObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/common/src/com/sony/transmitpower/observer/TelecommObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelecommObserver.java
@@ -9,7 +9,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.google.android.collect.Sets;
 

--- a/common/src/com/sony/transmitpower/observer/TelecommObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelecommObserver.java
@@ -11,11 +11,10 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
-import com.google.android.collect.Sets;
-
 import com.sony.transmitpower.service.InCallObserverService;
 import com.sony.transmitpower.util.Util;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -27,7 +26,7 @@ import java.util.Set;
 public final class TelecommObserver extends BroadcastReceiver {
     private static final String TAG = TelecommObserver.class.getCanonicalName();
 
-    private final Set<Listener> mListeners = Sets.newHashSet();
+    private final Set<Listener> mListeners = new HashSet();
     private boolean mIsCallActive = false;
     private boolean mIsBuiltinSpeaker = false;
 

--- a/common/src/com/sony/transmitpower/observer/TelecommObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelecommObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;

--- a/common/src/com/sony/transmitpower/observer/TelephonyStateObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelephonyStateObserver.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.observer;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.media.AudioManager;
 import android.telephony.PhoneStateListener;

--- a/common/src/com/sony/transmitpower/observer/TelephonyStateObserver.java
+++ b/common/src/com/sony/transmitpower/observer/TelephonyStateObserver.java
@@ -13,11 +13,10 @@ import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 
-import com.google.android.collect.Sets;
-
 import com.sony.transmitpower.util.Util;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -31,7 +30,7 @@ public final class TelephonyStateObserver {
 
     private TelephonyManager mTelephonyManager;
     private SubscriptionManager mSubscriptionManager;
-    private final Set<Listener> mListeners = Sets.newHashSet();
+    private final Set<Listener> mListeners = new HashSet();
     private final List<PhoneStateListenerImpl> mPhoneStateListeners =
             new ArrayList<>();
 

--- a/common/src/com/sony/transmitpower/service/InCallObserverService.java
+++ b/common/src/com/sony/transmitpower/service/InCallObserverService.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.service;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;

--- a/common/src/com/sony/transmitpower/service/InCallObserverService.java
+++ b/common/src/com/sony/transmitpower/service/InCallObserverService.java
@@ -8,7 +8,7 @@ import androidx.annotation.NonNull;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.telecom.Call;
 import android.telecom.CallAudioState;
 import android.telecom.InCallService;

--- a/common/src/com/sony/transmitpower/util/Util.java
+++ b/common/src/com/sony/transmitpower/util/Util.java
@@ -4,8 +4,8 @@
  */
 package com.sony.transmitpower.util;
 
-import android.annotation.NonNull;
-import android.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;

--- a/libacc/src/com/sony/transmitpower/sensor/Accelerometer.java
+++ b/libacc/src/com/sony/transmitpower/sensor/Accelerometer.java
@@ -11,11 +11,10 @@ import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 
-import com.google.android.collect.Sets;
-
 import com.sony.transmitpower.sensor.util.Vector;
 import com.sony.transmitpower.util.Util;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -42,7 +41,7 @@ public final class Accelerometer
     private int mSampleCount = 0;
     private Vector mRunningSum = new Vector(0.0f, 0.0f, 0.0f);
 
-    private final Set<Listener> mListeners = Sets.newHashSet();
+    private final Set<Listener> mListeners = new HashSet();
 
     public interface Listener {
         void onMotionStateChanged(boolean isStable);

--- a/libacc/src/com/sony/transmitpower/sensor/Accelerometer.java
+++ b/libacc/src/com/sony/transmitpower/sensor/Accelerometer.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.content.Context;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;

--- a/libacc/src/com/sony/transmitpower/sensor/util/Vector.java
+++ b/libacc/src/com/sony/transmitpower/sensor/util/Vector.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor.util;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class Vector {
     public float x;

--- a/libpower/Android.mk
+++ b/libpower/Android.mk
@@ -11,6 +11,4 @@ LOCAL_PROPRIETARY_MODULE := true
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
-LOCAL_JAVA_LIBRARIES += telephony-common
-
 include $(BUILD_STATIC_JAVA_LIBRARY)

--- a/libproximity/src/com/sony/transmitpower/sensor/Proximity.java
+++ b/libproximity/src/com/sony/transmitpower/sensor/Proximity.java
@@ -4,7 +4,7 @@
  */
 package com.sony.transmitpower.sensor;
 
-import android.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;

--- a/libproximity/src/com/sony/transmitpower/sensor/Proximity.java
+++ b/libproximity/src/com/sony/transmitpower/sensor/Proximity.java
@@ -9,10 +9,9 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 
-import com.google.android.collect.Sets;
-
 import com.sony.transmitpower.util.Util;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -25,7 +24,7 @@ public final class Proximity
         implements SensorEventListener {
     private static final String TAG = Proximity.class.getCanonicalName();
 
-    private final Set<Listener> mListeners = Sets.newHashSet();
+    private final Set<Listener> mListeners = new HashSet();
 
     public interface Listener {
         void onProximityStateChanged(boolean isNear);


### PR DESCRIPTION
Depends on https://github.com/sonyxperiadev/transpower/pull/12

These patches convert most of the remaining private classes/methods to publicly available components, which will help smoothen the transition away from `private_apis` to `sdk_version` compliancy.

### DONOTMERGE:
Unlike the original code this patch handles the error coming from `invokeOemRilRequestRaw`, consequently throwing an `IllegalArgumentException` instead of silently ignoring it.

See [this post](https://github.com/sonyxperiadev/transpower/pull/11#issuecomment-599112185) for more details. [This](https://github.com/MarijnS95/transpower/commit/98b2613ec0e031047fbaaf537cf35c6eb200efaa) commit can be picked to catch error messages on the current revision as well.