### PR TITLE
libpower/transmitter: Don't consider SET_TRANSMIT_POWER failure fatal

### DIFF
--- a/libpower/src/com/sony/transmitpower/Transmitter.java
+++ b/libpower/src/com/sony/transmitpower/Transmitter.java
@@ -53,7 +53,7 @@ public final class Transmitter {
         byte[] resp = new byte[1024];
         int ret = telephonyManager.invokeOemRilRequestRaw(buf.array(), resp);
         if (ret < 0)
-            throw new IllegalArgumentException("invokeOemRilRequestRaw failed with rc = " + ret);
+            Log.e(TAG, "invokeOemRilRequestRaw SET_TRANSMIT_POWER failed with rc = " + ret);
     }
 
     private static boolean validate(final int key, final int value) {


### PR DESCRIPTION
We already know that SAR backoff doesn't work, and were previously conveniently ignoring any failures.  The transition to TelephonyManager in [#13] changed that and considers this to be fatal, but unless external help comes in to guide testing on the new commands and command structure (see open PRs) we should stick to the ignorant world and let this misbehaviour slip through.  Which is "better" than crashing transpower, in turn taking the telephony stack down and allowing PartyCrasher (RescueParty, for the uninitiated) to make your phone useless.

[#13]: https://github.com/sonyxperiadev/transpower/pull/13

Fixes: 21cdf15 ("libpower: Switch to TelephonyManager.")
