### PR TITLE
common: Include privapp-permissions file directly through `TransPowerCommon` library

### DIFF
--- a/common/Android.bp
+++ b/common/Android.bp
@@ -9,6 +9,8 @@ java_library {
 
     srcs: ["src/**/*.java"],
 
+    required: ["privapp-permissions-transmitpower"],
+
     static_libs: [
         "androidx.annotation_annotation",
         "androidx.localbroadcastmanager_localbroadcastmanager",
@@ -32,8 +34,7 @@ android_library {
 }
 
 prebuilt_etc {
-
-    name: "privapp-permissions-transmitpower.xml",
+    name: "privapp-permissions-transmitpower",
     src: "privapp-permissions-transmitpower.xml",
     system_ext_specific: true,
     sub_dir: "permissions",


### PR DESCRIPTION
The current setup is far from ideal and extremely error-prone as it requires every device to depend on this file individually in addition to `TransPowerSensors` (depends on `TransPowerCommon` under the hood), also because this package is configured _per device_ instead of per platform/board, or straight in the `common` device repo...

Disclaimer: THIS CHANGE HAS **NOT** BEEN BUILD-TESTED.  @jerpelea please drop the dependency from all device repos again to clean up the mess and to prevent build errors as this PR also renames the `prebuilt_etc` target name (without changing `stem`) to match what we do in `modemconfig`.
